### PR TITLE
Avoid general word for namespace

### DIFF
--- a/image-picker-rails.gemspec
+++ b/image-picker-rails.gemspec
@@ -5,7 +5,7 @@ require 'image-picker-rails/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "image-picker-rails"
-  spec.version       = Image::Picker::Rails::VERSION
+  spec.version       = ImagePickerRails::VERSION
   spec.authors       = ["Airat Shigapov"]
   spec.email         = ["airat@shigapov.me"]
   spec.description   = "Image Picker is a simple jQuery plugin that transforms a select element into a more user friendly graphical interface."

--- a/lib/image-picker-rails/version.rb
+++ b/lib/image-picker-rails/version.rb
@@ -1,7 +1,3 @@
-module Image
-  module Picker
-    module Rails
-      VERSION = "0.2.4"
-    end
-  end
+module ImagePickerRails
+  VERSION = "0.2.4"
 end


### PR DESCRIPTION
`Image` is too general, so that it easily conflicts with other class such as ActiveRecord model.
`ImagePickerRails` which is used in `image-picker-rails.rb` seems to be more suitable as namespace.
